### PR TITLE
Convert from node_xslt to node-libxslt

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-xslt",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "XSLT transformation plugin for gulp",
   "main": "index.js",
   "keywords": [
@@ -13,9 +13,9 @@
     "url": "git://github.com/vecmezoni/gulp-xslt.git"
   },
   "dependencies": {
-    "node_xslt": "~0.1.9",
     "event-stream": "~3.1.7",
-    "gulp-util": "~3.0.1"
+    "gulp-util": "~3.0.1",
+    "libxslt": "~0.6.3"
   },
   "author": {
     "name": "Alexander Inozemtsev",
@@ -35,7 +35,7 @@
     "mocha": "*",
     "gulp": "~3.8.10",
     "stream-assert": "~2.0.2",
-    "libxml-xsd": "~0.2.0"
+    "libxml-xsd": "~0.5.0"
   },
   "engineStrict": true,
   "engines": {

--- a/test/test.js
+++ b/test/test.js
@@ -80,7 +80,7 @@ describe('gulp-xslt', function() {
         gulp.src(fixtures('/3/*.xml'))
             .pipe(xslt(fixtures('/2/template.xsl')))
             .on('error', function (err) {
-                err.message.should.eql('Failed to parse XML');
+                err.message.should.match(/Premature end of data/);
                 done();
             });
     });
@@ -88,13 +88,13 @@ describe('gulp-xslt', function() {
     it('should throw on broken XSL', function() {
         (function () {
             xslt(fixtures('/3/template.xsl'));
-        }).should.throw('Failed to parse stylesheet');
+        }).should.throw(/Could not parse XML string as XSLT stylesheet/);
     });
 
     it('should throw on nonexistent XSL', function() {
         (function () {
             xslt(fixtures('/4/template.xsl'));
-        }).should.throw('Failed to parse XML');
+        }).should.throw(/no such file or directory/);
     });
 
 });


### PR DESCRIPTION
Note that the exception messages differ, so I bumped the minor version.

```
Passes self-tests with node v5.5.0 and npm v3.3.12 on Fedora Linux 23, x86_64.
```
